### PR TITLE
Upgrades to test actions workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
           environment-name: pysample-test
           environment-file: ci/environment.yml
           extra-specs: |
-            python=3.10'
+            python=3.10
           # mamba-version: '*'
           # channels: conda-forge
           # auto-activate-base: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,16 +13,18 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: conda-incubator/setup-miniconda@v2
       - name: Checkout repository
         uses: actions/checkout@v3
+      - name : Install Conda env with Micromamba
+        uses: mamba-org/provision-with-micromamba@main
         with:
-          activate-environment: pysample-test
+          environment-name: pysample-test
           environment-file: ci/environment.yml
-          python-version: '3.10'
-          mamba-version: '*'
-          channels: conda-forge
-          auto-activate-base: false
+          extra-specs: |
+            python=3.10'
+          # mamba-version: '*'
+          # channels: conda-forge
+          # auto-activate-base: false
       - name: Install pysample
         run: |
           pip install -e .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,9 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2
+      - name: Checkout repository
+        uses: actions/checkout@v3
         with:
           activate-environment: pysample-test
           environment-file: ci/environment.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,5 @@ repos:
     rev: 4.0.1
     hooks:
       - id: flake8
+        args:
+          - "--max-line-length=88"

--- a/src/pysample.py
+++ b/src/pysample.py
@@ -6,9 +6,9 @@ import numpy as np
 
 
 def create_array():
-    """
-    Return a 3x3 np.ndarray of zeroes.
+    """Return a 3x3 np.ndarray of zeroes.
 
+    :return: 3x3 np.ndarray of zeroes
     :rtype: np.ndarray
     """
     return np.zeros(shape=(3, 3))

--- a/src/pysample.py
+++ b/src/pysample.py
@@ -12,3 +12,21 @@ def create_array():
     :rtype: np.ndarray
     """
     return np.zeros(shape=(3, 3))
+
+
+def create_rand_array(mean: float = 0.0, stdev: float = 1.0, shape: tuple = (3, 3)):
+    """Creates an ndarray with the given shape, mean, and standard deviation.
+
+    :param mean: mean of the array, defaults to 0.0
+    :type mean: float, optional
+    :param stdev: standard deviation of the array, defaults to 1.0
+    :type stdev: float, optional
+    :param shape: shape of the array, defaults to (3, 3)
+    :type shape: tuple, optional
+    :return: ndarray of the given shape with values equal to mean and stdev
+    :rtype: np.ndarray
+    """
+
+    arr = np.zeros(shape=shape)
+
+    return np.random.normal(loc=mean, scale=stdev, size=arr.size).reshape(arr.shape)

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -1,7 +1,21 @@
 import numpy as np
+import pytest
 
 
 def test_create_array():
     from pysample import create_array
 
     assert np.array_equal(create_array(), np.zeros(shape=(3, 3)))
+
+
+def test_create_rand_array():
+    from pysample import create_rand_array
+
+    test_mean = 5
+    test_std = 1
+    test_shape = (3, 3)
+
+    arr = create_rand_array(test_mean, test_std, test_shape)
+    assert arr.mean() == pytest.approx(test_mean, 0.1)
+    assert arr.std() == pytest.approx(test_std, 0.5)
+    assert arr.shape == test_shape

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 88


### PR DESCRIPTION
In test workflow:
- Bump version of checkout action from 2 to 3
- Switch from Conda to micromamba

In pre commit hook:
- Set flake8 max line length to 88 to match Black autoformatter default

In `pysample`:
- Add random array test
- Minor docs update
